### PR TITLE
fix(autoware_planning_rviz_plugin): memory leak in scene node management

### DIFF
--- a/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display.hpp
+++ b/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display.hpp
@@ -207,8 +207,7 @@ private:
   rviz_common::properties::BoolProperty property_lane_id_view_;
   rviz_common::properties::FloatProperty property_lane_id_scale_;
 
-  using LaneIdObject =
-    std::pair<std::unique_ptr<Ogre::SceneNode>, std::unique_ptr<rviz_rendering::MovableText>>;
+  using LaneIdObject = std::pair<Ogre::SceneNode *, std::unique_ptr<rviz_rendering::MovableText>>;
   std::vector<LaneIdObject> lane_id_obj_ptrs_;
 };
 


### PR DESCRIPTION
## Description

This PR fixes a memory leak issue in the AutowarePathWithLaneIdDisplay class where Ogre::SceneNode objects were not being properly destroyed. The original implementation used std::unique_ptr to manage SceneNode objects, but these nodes are actually managed by the SceneManager and require explicit destruction through the SceneManager API.

### Changes

- Changed LaneIdObject typedef from std::unique_ptr<Ogre::SceneNode> to raw Ogre::SceneNode* pointer
- Added proper cleanup in destructor with detachAllObjects(), removeAndDestroyAllChildren(), and destroySceneNode() calls  
- Optimized preVisualizePathFootprintDetail() to reuse existing objects instead of recreating them every time
- Implemented dynamic resizing logic that only creates/destroys objects when the size changes
- Added proper visibility management for existing text objects

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
