### PR TITLE
feat(workflows): add workflows for version control automation

### DIFF
--- a/.github/workflows/bump-new-version.yaml
+++ b/.github/workflows/bump-new-version.yaml
@@ -1,0 +1,46 @@
+name: bump-new-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: The branch to merge from, which can be from the original or a forked repository.
+        required: true
+        default: main
+      target_branch:
+        description: The branch to merge into, owned by the original repository owner.
+        required: true
+        default: main
+      bump_version:
+        description: The type of version bump to apply.
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      source_repository_owner:
+        description: The owner of the source repository (organization or user).
+        required: false
+        default: autowarefoundation
+
+jobs:
+  update-versions:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run
+        uses: autowarefoundation/autoware-github-actions/bump-new-version@v1
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          source_branch: ${{ github.event.inputs.source_branch }}
+          target_branch: ${{ github.event.inputs.target_branch }}
+          bump_version: ${{ github.event.inputs.bump_version }}
+          source_repository_owner: ${{ github.event.inputs.source_repository_owner }}

--- a/.github/workflows/release-new-version-when-merged.yaml
+++ b/.github/workflows/release-new-version-when-merged.yaml
@@ -1,0 +1,28 @@
+name: tag release after PR merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  tag-on-merge:
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(
+        join(github.event.pull_request.labels.*.name, ','),
+        'release:bump-version'
+      )
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run
+        uses: autowarefoundation/autoware-github-actions/release-new-tag-when-merged@v1
+        with:
+          github_token: ${{ steps.generate-token.outputs.token }}
+          commit_sha: ${{ github.event.pull_request.merge_commit_sha }}


### PR DESCRIPTION
## Description

### Overview

This pull request introduces two new GitHub Actions workflows designed to automate version management and tagging processes for our packages:

1. **`release-new-tag-when-merged`**: Automatically creates a new tag when a pull request, created by the `bump-new-version` workflow, is merged. This ensures that every merge results in a new version tag based on the version specified in the `package.xml` files.

2. **`bump-new-version`**: Automates the process of bumping the version in `package.xml` files and creating a pull request with the updated version and changelog. This workflow supports patch, minor, and major version bumps, and ensures version consistency across all package files.

## How was this PR tested?

Please see the following link's PR description. We tested by using testing purpose repository to trigger the workflow directly.
- https://github.com/autowarefoundation/autoware-github-actions/pull/348
- https://github.com/autowarefoundation/autoware-github-actions/pull/350

## Notes for reviewers

You need to trigger the workflow manually via `bump-new-version`

## Effects on system behavior

Two workflows will be added in this repository.