### PR TITLE
fix(autoware_string_stamped_overlay_rviz_plugin): clear overlay if message timestamp is old

### DIFF
--- a/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/src/string_stamped_overlay_display.cpp
+++ b/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/src/string_stamped_overlay_display.cpp
@@ -159,7 +159,8 @@ void StringStampedOverlayDisplay::update(float wall_dt, float ros_dt)
       const auto duration = (current_time - last_non_empty_msg_ptr_->stamp).seconds();
       if (
         duration <
-        property_last_diag_keep_time_->getFloat() + property_last_diag_erase_time_->getFloat()) {
+        property_last_diag_keep_time_->getFloat() + property_last_diag_erase_time_->getFloat() &&
+        duration > 0.0) {
         const int dynamic_alpha = static_cast<int>(std::max(
           (1.0 - std::max(duration - property_last_diag_keep_time_->getFloat(), 0.0) /
                    property_last_diag_erase_time_->getFloat()) *

--- a/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/src/string_stamped_overlay_display.cpp
+++ b/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/src/string_stamped_overlay_display.cpp
@@ -159,7 +159,7 @@ void StringStampedOverlayDisplay::update(float wall_dt, float ros_dt)
       const auto duration = (current_time - last_non_empty_msg_ptr_->stamp).seconds();
       if (
         duration <
-        property_last_diag_keep_time_->getFloat() + property_last_diag_erase_time_->getFloat() &&
+          property_last_diag_keep_time_->getFloat() + property_last_diag_erase_time_->getFloat() &&
         duration > 0.0) {
         const int dynamic_alpha = static_cast<int>(std::max(
           (1.0 - std::max(duration - property_last_diag_keep_time_->getFloat(), 0.0) /


### PR DESCRIPTION
## Description
The autoware_string_stamped_overlay_rviz_plugin keeps text displayed for a certain amount of time. This makes it difficult for me to determine if a message is the latest one when I repeatedly play a rosbag. This pull request changes the plugin to clear the displayed text if the timestamp is old.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I tested with a rosbag.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
