### PR TITLE
feat(autoware_overlay_rviz_plugin): add Last-in priority  for turn signal and  hazard light

### DIFF
--- a/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
+++ b/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
@@ -62,6 +62,7 @@ private Q_SLOTS:
   void updateOverlayPosition();
   void updateOverlayColor();
   void updateTurnSignalBlinkingMode();
+  void updateTurnSignalPriority();
   void topic_updated_gear();
   void topic_updated_steering();
   void topic_updated_speed();
@@ -86,6 +87,7 @@ private:
   rviz_common::properties::ColorProperty * property_dark_limit_color_;
 
   rviz_common::properties::EnumProperty * property_turn_signal_blinking_mode_;
+  rviz_common::properties::EnumProperty * property_turn_signal_priority_;
 
   std::unique_ptr<rviz_common::properties::RosTopicProperty> steering_topic_property_;
   std::unique_ptr<rviz_common::properties::RosTopicProperty> gear_topic_property_;

--- a/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/turn_signals_display.hpp
+++ b/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/turn_signals_display.hpp
@@ -46,15 +46,19 @@ public:
   void updateHazardLightsData(
     const autoware_vehicle_msgs::msg::HazardLightsReport::ConstSharedPtr & msg);
   void setBlinkingMode(std::string_view mode);
+  void setPriority(std::string_view mode);
 
 private:
   QImage arrowImage;
   QColor gray = QColor(79, 79, 79);
 
   std::string blinking_mode_ = "Static";
+  std::string priority_ = "Hazard";
 
   int current_turn_signal_;    // Internal variable to store turn signal state
   int current_hazard_lights_;  // Internal variable to store hazard lights state
+  double turn_signal_time_; // Internal variable to store time when hazard lights on
+  double hazard_lights_time_; // Internal variable to store time when hazard lights on
   QImage coloredImage(const QImage & source, const QColor & color);
 };
 

--- a/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
+++ b/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
@@ -72,6 +72,11 @@ SignalDisplay::SignalDisplay()
     SLOT(updateTurnSignalBlinkingMode()));
   property_turn_signal_blinking_mode_->addOption("Static", 0);
   property_turn_signal_blinking_mode_->addOption("Blinking", 1);
+  property_turn_signal_priority_ = new rviz_common::properties::EnumProperty(
+    "Signal Priority Mode", "Hazard", "Priority of the signal light", this,
+    SLOT(updateTurnSignalPriority()));
+  property_turn_signal_priority_->addOption("Hazard", 0);
+  property_turn_signal_priority_->addOption("Last-in", 1);
 
   // Initialize the component displays
   steering_wheel_display_ = std::make_unique<SteeringWheelDisplay>();
@@ -403,6 +408,15 @@ void SignalDisplay::updateTurnSignalBlinkingMode()
   std::lock_guard<std::mutex> lock(mutex_);
   if (turn_signals_display_) {
     turn_signals_display_->setBlinkingMode(property_turn_signal_blinking_mode_->getStdString());
+  }
+  queueRender();
+}
+
+void SignalDisplay::updateTurnSignalPriority()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (turn_signals_display_) {
+    turn_signals_display_->setPriority(property_turn_signal_priority_->getStdString());
   }
   queueRender();
 }


### PR DESCRIPTION
## Description
The current plugin prioritizes the hazard lights. We've added a new mode to the turn signal and hazard light logic that gives priority to the most recent signal.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
