### PR TITLE
feat(autoware_planning_rviz_plugin): add pose visualization as an arrow

### DIFF
--- a/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
+++ b/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
@@ -173,7 +173,6 @@ public:
     // initialize point
     property_point_alpha_.setMin(0.0);
     property_point_alpha_.setMax(1.0);
-    property_point_radius_.setMin(0.0);
     // initialize pose
     property_pose_alpha_.setMin(0.0);
     property_pose_alpha_.setMax(1.0);

--- a/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
+++ b/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
@@ -638,10 +638,14 @@ protected:
         const double offset = property_pose_offset_.getFloat();
         const double yaw = tf2::getYaw(pose.orientation);
         const double arrow_length = property_pose_arrow_length_.getFloat();
-        const double head_length = arrow_length * 0.4;
-        const double head_width = arrow_length * 0.5;  // Make head wider and more visible
+        constexpr static double HEAD_LENGTH_RATIO = 0.4;
+        constexpr static double HEAD_WIDTH_RATIO = 0.5;
+        constexpr static double SHAFT_WIDTH_RATIO = 0.15;
+
+        const double head_length = arrow_length * HEAD_LENGTH_RATIO;
+        const double head_width = arrow_length * HEAD_WIDTH_RATIO;
         const double shaft_length = arrow_length - head_length;
-        const double shaft_width = arrow_length * 0.15;
+        const double shaft_width = arrow_length * SHAFT_WIDTH_RATIO;
 
         const double cos_yaw = std::cos(yaw);
         const double sin_yaw = std::sin(yaw);

--- a/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
+++ b/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
@@ -644,12 +644,11 @@ protected:
         const double shaft_length = arrow_length - head_length;
         const double shaft_width = arrow_length * 0.15;
 
-        const double origin_x = pose.position.x + offset * std::cos(yaw);
-        const double origin_y = pose.position.y + offset * std::sin(yaw);
-        const double origin_z = pose.position.z;
-
         const double cos_yaw = std::cos(yaw);
         const double sin_yaw = std::sin(yaw);
+        const double origin_x = pose.position.x + offset * cos_yaw;
+        const double origin_y = pose.position.y + offset * sin_yaw;
+        const double origin_z = pose.position.z;
         const double p0_x = origin_x - shaft_width / 2.0 * sin_yaw;
         const double p0_y = origin_y + shaft_width / 2.0 * cos_yaw;
         const double p1_x = origin_x + shaft_width / 2.0 * sin_yaw;

--- a/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
+++ b/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
@@ -142,6 +142,12 @@ public:
     property_point_color_{"Color", QColor(0, 60, 255), "", &property_point_view_},
     property_point_radius_{"Radius", 0.1, "", &property_point_view_},
     property_point_offset_{"Offset", 0.0, "", &property_point_view_},
+    // pose
+    property_pose_view_{"View Pose", false, "", this},
+    property_pose_alpha_{"Alpha", 1.0, "", &property_pose_view_},
+    property_pose_color_{"Color", QColor(255, 60, 0), "", &property_pose_view_},
+    property_pose_arrow_length_{"Arrow Length", 0.3, "", &property_pose_view_},
+    property_pose_offset_{"Offset", 0.0, "", &property_pose_view_},
     // slope
     property_slope_text_view_{"View Text Slope", false, "", this},
     property_slope_text_scale_{"Scale", 0.3, "", &property_slope_text_view_}
@@ -167,6 +173,11 @@ public:
     // initialize point
     property_point_alpha_.setMin(0.0);
     property_point_alpha_.setMax(1.0);
+    property_point_radius_.setMin(0.0);
+    // initialize pose
+    property_pose_alpha_.setMin(0.0);
+    property_pose_alpha_.setMax(1.0);
+    property_pose_arrow_length_.setMin(0.0);
 
     updateVehicleInfo();
   }
@@ -534,7 +545,13 @@ protected:
 
     footprint_manual_object_->estimateVertexCount(msg_ptr->points.size() * 4 * 2);
     footprint_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_LINE_LIST);
-    point_manual_object_->estimateVertexCount(msg_ptr->points.size() * 3 * 8);
+
+    // Estimate for both points (circles) and poses (arrows)
+    const size_t point_triangles =
+      property_point_view_.getBool() ? 8 * 3 : 0;                         // 8 triangles per circle
+    const size_t pose_triangles = property_pose_view_.getBool() ? 3 : 0;  // 3 triangles per arrow
+    point_manual_object_->estimateVertexCount(
+      msg_ptr->points.size() * (point_triangles + pose_triangles));
     point_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);
 
     preVisualizePathFootprintDetail(msg_ptr);
@@ -613,6 +630,65 @@ protected:
         }
       }
 
+      // Pose - visualized as arrows showing pose direction
+      if (property_pose_view_.getBool()) {
+        Ogre::ColourValue color;
+        color = rviz_common::properties::qtToOgre(property_pose_color_.getColor());
+        color.a = property_pose_alpha_.getFloat();
+
+        const double offset = property_pose_offset_.getFloat();
+        const double yaw = tf2::getYaw(pose.orientation);
+        const double arrow_length = property_pose_arrow_length_.getFloat();
+        const double head_length = arrow_length * 0.4;
+        const double head_width = arrow_length * 0.5;  // Make head wider and more visible
+        const double shaft_length = arrow_length - head_length;
+        const double shaft_width = arrow_length * 0.15;
+
+        const double origin_x = pose.position.x + offset * std::cos(yaw);
+        const double origin_y = pose.position.y + offset * std::sin(yaw);
+        const double origin_z = pose.position.z;
+
+        const double cos_yaw = std::cos(yaw);
+        const double sin_yaw = std::sin(yaw);
+        const double p0_x = origin_x - shaft_width / 2.0 * sin_yaw;
+        const double p0_y = origin_y + shaft_width / 2.0 * cos_yaw;
+        const double p1_x = origin_x + shaft_width / 2.0 * sin_yaw;
+        const double p1_y = origin_y - shaft_width / 2.0 * cos_yaw;
+        const double p2_x = origin_x + shaft_length * cos_yaw + shaft_width / 2.0 * sin_yaw;
+        const double p2_y = origin_y + shaft_length * sin_yaw - shaft_width / 2.0 * cos_yaw;
+        const double p3_x = origin_x + shaft_length * cos_yaw - shaft_width / 2.0 * sin_yaw;
+        const double p3_y = origin_y + shaft_length * sin_yaw + shaft_width / 2.0 * cos_yaw;
+
+        point_manual_object_->position(p0_x, p0_y, origin_z);
+        point_manual_object_->colour(color);
+        point_manual_object_->position(p1_x, p1_y, origin_z);
+        point_manual_object_->colour(color);
+        point_manual_object_->position(p2_x, p2_y, origin_z);
+        point_manual_object_->colour(color);
+
+        point_manual_object_->position(p0_x, p0_y, origin_z);
+        point_manual_object_->colour(color);
+        point_manual_object_->position(p2_x, p2_y, origin_z);
+        point_manual_object_->colour(color);
+        point_manual_object_->position(p3_x, p3_y, origin_z);
+        point_manual_object_->colour(color);
+
+        // Arrow head (triangle)
+        const double tip_x = origin_x + arrow_length * cos_yaw;
+        const double tip_y = origin_y + arrow_length * sin_yaw;
+        const double base_left_x = origin_x + shaft_length * cos_yaw - head_width / 2.0 * sin_yaw;
+        const double base_left_y = origin_y + shaft_length * sin_yaw + head_width / 2.0 * cos_yaw;
+        const double base_right_x = origin_x + shaft_length * cos_yaw + head_width / 2.0 * sin_yaw;
+        const double base_right_y = origin_y + shaft_length * sin_yaw - head_width / 2.0 * cos_yaw;
+
+        point_manual_object_->position(base_left_x, base_left_y, origin_z);
+        point_manual_object_->colour(color);
+        point_manual_object_->position(base_right_x, base_right_y, origin_z);
+        point_manual_object_->colour(color);
+        point_manual_object_->position(tip_x, tip_y, origin_z);
+        point_manual_object_->colour(color);
+      }
+
       visualizePathFootprintDetail(msg_ptr, p_idx);
     }
 
@@ -682,6 +758,12 @@ protected:
   rviz_common::properties::ColorProperty property_point_color_;
   rviz_common::properties::FloatProperty property_point_radius_;
   rviz_common::properties::FloatProperty property_point_offset_;
+
+  rviz_common::properties::BoolProperty property_pose_view_;
+  rviz_common::properties::FloatProperty property_pose_alpha_;
+  rviz_common::properties::ColorProperty property_pose_color_;
+  rviz_common::properties::FloatProperty property_pose_arrow_length_;
+  rviz_common::properties::FloatProperty property_pose_offset_;
 
   rviz_common::properties::BoolProperty property_slope_text_view_;
   rviz_common::properties::FloatProperty property_slope_text_scale_;

--- a/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
+++ b/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
@@ -547,8 +547,9 @@ protected:
 
     // Estimate for both points (circles) and poses (arrows)
     const size_t point_triangles =
-      property_point_view_.getBool() ? 8 * 3 : 0;                         // 8 triangles per circle
-    const size_t pose_triangles = property_pose_view_.getBool() ? 9 : 0;  // 3 triangles per arrow (9 vertices)
+      property_point_view_.getBool() ? 8 * 3 : 0;  // 8 triangles per circle
+    const size_t pose_triangles =
+      property_pose_view_.getBool() ? 9 : 0;  // 3 triangles per arrow (9 vertices)
     point_manual_object_->estimateVertexCount(
       msg_ptr->points.size() * (point_triangles + pose_triangles));
     point_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);

--- a/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
+++ b/autoware_planning_rviz_plugin/include/autoware_planning_rviz_plugin/path/display_base.hpp
@@ -549,7 +549,7 @@ protected:
     // Estimate for both points (circles) and poses (arrows)
     const size_t point_triangles =
       property_point_view_.getBool() ? 8 * 3 : 0;                         // 8 triangles per circle
-    const size_t pose_triangles = property_pose_view_.getBool() ? 3 : 0;  // 3 triangles per arrow
+    const size_t pose_triangles = property_pose_view_.getBool() ? 9 : 0;  // 3 triangles per arrow (9 vertices)
     point_manual_object_->estimateVertexCount(
       msg_ptr->points.size() * (point_triangles + pose_triangles));
     point_manual_object_->begin("BaseWhiteNoLighting", Ogre::RenderOperation::OT_TRIANGLE_LIST);


### PR DESCRIPTION
## Description
This PR adds trajectory pose visualization as an arrow which shaft starts in the `pose.position` and directed by `pose.orientation` 

<img width="1920" height="446" alt="Screenshot from 2025-11-18 08-54-50" src="https://github.com/user-attachments/assets/4a3f6dd3-01b6-4542-adee-7d223757d0af" />


<img width="787" height="902" alt="image" src="https://github.com/user-attachments/assets/baf0b98f-9cde-456c-8ad5-c100b4a4bb5b" />


## How was this PR tested?
Tested in rviz.
