### PR TITLE
refactor(autoware_rviz_plugins): use autoware_ament_auto_package

### DIFF
--- a/autoware_perception_rviz_plugin/CMakeLists.txt
+++ b/autoware_perception_rviz_plugin/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 # Export the plugin to be imported by rviz2
 pluginlib_export_plugin_description_file(rviz_common plugins_description.xml)
 
-ament_auto_package(
+autoware_ament_auto_package(
   INSTALL_TO_SHARE
   icons
 )

--- a/autoware_planning_rviz_plugin/CMakeLists.txt
+++ b/autoware_planning_rviz_plugin/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(autoware_planning_rviz_plugin
 # Export the plugin to be imported by rviz2
 pluginlib_export_plugin_description_file(rviz_common plugins/plugin_description.xml)
 
-ament_auto_package(
+autoware_ament_auto_package(
   INSTALL_TO_SHARE
   icons
   plugins


### PR DESCRIPTION
## Description

This PR replaces `ament_auto_package()` with `autoware_ament_auto_package()` for packages in `autoware_rviz_plugins` that emitted scoped header installation warnings during the clean build investigation.

Updated packages:
- `autoware_perception_rviz_plugin`
- `autoware_planning_rviz_plugin`

## How was this PR tested?

Tested with:

```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_planning_rviz_plugin autoware_perception_rviz_plugin
```

Both target packages built successfully.

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Effects on system behavior

No functional behavior change is intended. This updates the package macro to the Autoware wrapper for the scoped header migration work.
