### PR TITLE
fix: call update_value_type in onInitialize

### DIFF
--- a/autoware_localization_rviz_plugin/src/colored_pose_with_covariance_history/colored_pose_with_covariance_history_display.cpp
+++ b/autoware_localization_rviz_plugin/src/colored_pose_with_covariance_history/colored_pose_with_covariance_history_display.cpp
@@ -101,6 +101,7 @@ void ColoredPoseWithCovarianceHistory::onInitialize()
   }
 
   property_value_topic_->initialize(node_abstraction);
+  update_value_type();
 }
 
 void ColoredPoseWithCovarianceHistory::onEnable()


### PR DESCRIPTION
## Description

Fixes an intermittent topic type mismatch issue in the `ColoredPoseWithCovarianceHistory` RViz plugin.

Currently, depending on the initialization timing, the plugin might subscribe to the topic with an uninitialized `current_value_type_` (which defaults to `Int32`) before the `property_value_type_` from the RViz config is fully applied. This timing issue can cause a type conflict on the topic (e.g., mixing `Float32Stamped` and `Int32Stamped`).

To prevent this, this PR adds a call to `update_value_type()` at the end of `onInitialize()`. This explicitly ensures that `current_value_type_` is updated with the correct configuration value before any subscription happens in `onEnable()`.

<img width="1979" height="227" alt="image" src="https://github.com/user-attachments/assets/36ceff2d-052c-4ffd-9838-06d43bf60923" />


## Related links

**Parent Issue:**

- N/A

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Since this is a timing-dependent issue, it occurs intermittently.
1. Launch logging_simulator.launch.xml
2. Open and close RViz multiple times.
3. Check the topic info and confirm that the Int32Stamped type is no longer observed:
```bash
ros2 topic info -v /localization/pose_estimator/nearest_voxel_transformation_likelihood | grep -E 'Node name|Topic type'
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
