### PR TITLE
ci(docker): switch CI to core-devel-humble images

### DIFF
--- a/.github/actions/tune-dds-network/action.yaml
+++ b/.github/actions/tune-dds-network/action.yaml
@@ -1,0 +1,36 @@
+name: Tune DDS network settings
+description: |
+  Apply the DDS tweaks that docker-entrypoint.sh would have done, since
+  GitHub Actions overrides the image entrypoint with `tail -f /dev/null`.
+  The calling job's container must include `--cap-add=NET_ADMIN`.
+
+runs:
+  using: composite
+  steps:
+    - name: 📡 Enable multicast on loopback
+      run: |
+        if ip link set lo multicast on; then
+          echo "✅ multicast enabled on lo"
+        else
+          echo "::warning title=DDS tuning::could not enable multicast on lo (NET_ADMIN missing?)"
+        fi
+      shell: bash
+
+    - name: 🩹 Relax CycloneDDS receive buffer requirement
+      # Bridge until autowarefoundation/autoware ships min="default" in cyclonedds.xml.
+      run: |
+        if [ -f /home/aw/cyclonedds.xml ]; then
+          sed -i 's|min="10MB"|min="default"|' /home/aw/cyclonedds.xml
+          echo "✅ patched: SocketReceiveBufferSize min=\"default\""
+        else
+          echo "::notice title=DDS tuning::/home/aw/cyclonedds.xml not present, skipping patch"
+        fi
+      shell: bash
+
+    - name: 🔍 Show effective DDS-relevant settings
+      run: |
+        printf '  %-22s = %s\n' "net.core.rmem_max"     "$(cat /proc/sys/net/core/rmem_max         2>/dev/null || echo unknown)"
+        printf '  %-22s = %s\n' "net.ipv4.ipfrag_time"  "$(cat /proc/sys/net/ipv4/ipfrag_time      2>/dev/null || echo unknown)"
+        printf '  %-22s = %s\n' "net.ipv4.ipfrag_high"  "$(cat /proc/sys/net/ipv4/ipfrag_high_thresh 2>/dev/null || echo unknown)"
+        printf '  %-22s : %s\n' "lo flags"              "$(ip -o link show lo 2>/dev/null | head -1 || echo unknown)"
+      shell: bash

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -9,8 +9,7 @@ jobs:
   build-and-test-daily:
     uses: ./.github/workflows/build-and-test-reusable.yaml
     with:
-      container: ghcr.io/autowarefoundation/autoware:core-devel
-      container-suffix: ""
+      container: ghcr.io/autowarefoundation/autoware:core-devel-humble
       pull-ccache: true
       concurrency-group: build-and-test-daily-${{ github.ref }}-${{ github.run_id }}
       codecov-flag: daily

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -18,10 +18,6 @@ on:
         default: true
         required: false
         type: boolean
-      container-suffix:
-        required: false
-        default: ""
-        type: string
       build-pre-command:
         required: false
         default: ""
@@ -33,12 +29,16 @@ on:
 env:
   CC: /usr/lib/ccache/gcc
   CXX: /usr/lib/ccache/g++
+  CCACHE_DIR: /root/.ccache
+  BUILD_TYPE_CUDA_STATE: ${{ contains(inputs.container, '-cuda') && 'cuda' || 'nocuda' }}
 
 jobs:
   build-and-test-differential:
     if: ${{ inputs.run-condition }}
     runs-on: ${{ inputs.runner }}
-    container: ${{ inputs.container }}${{ inputs.container-suffix }}
+    container:
+      image: ${{ inputs.container }}
+      options: --cap-add=NET_ADMIN
     steps:
       - name: Set PR fetch depth
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
@@ -49,6 +49,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Tune DDS network settings
+        uses: ./.github/actions/tune-dds-network
 
       - name: Show disk space before the tasks
         run: df -h
@@ -86,16 +89,6 @@ jobs:
           ccache --zero-stats
         shell: bash
 
-      - name: Export CUDA state as a variable for adding to cache key
-        run: |
-          build_type_cuda_state=nocuda
-          if [[ "${{ inputs.container-suffix }}" == "-cuda" ]]; then
-            build_type_cuda_state=cuda
-          fi
-          echo "BUILD_TYPE_CUDA_STATE=$build_type_cuda_state" >> "${GITHUB_ENV}"
-          echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
-        shell: bash
-
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
@@ -125,7 +118,7 @@ jobs:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
-          flags: differential${{ inputs.container-suffix }}
+          flags: differential${{ contains(inputs.container, '-cuda') && '-cuda' || '' }}
           token: ${{ secrets.codecov-token }}
 
       - name: Show disk space after the tasks

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -11,11 +11,7 @@ on:
         required: false
       container:
         type: string
-        default: ghcr.io/autowarefoundation/autoware:universe-devel
-        required: false
-      container-suffix:
-        type: string
-        default: ""
+        default: ghcr.io/autowarefoundation/autoware:core-devel-humble
         required: false
       rosdistro:
         type: string
@@ -56,16 +52,23 @@ concurrency:
 env:
   CC: /usr/lib/ccache/gcc
   CXX: /usr/lib/ccache/g++
+  CCACHE_DIR: /root/.ccache
+  BUILD_TYPE_CUDA_STATE: ${{ contains(inputs.container, '-cuda') && 'cuda' || 'nocuda' }}
 
 jobs:
   build-and-test:
     runs-on: ${{ fromJson(inputs.runner) }}
-    container: ${{ inputs.container }}${{ inputs.container-suffix }}
+    container:
+      image: ${{ inputs.container }}
+      options: --cap-add=NET_ADMIN
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Tune DDS network settings
+        uses: ./.github/actions/tune-dds-network
 
       - name: Show disk space before the tasks
         run: df -h
@@ -111,16 +114,6 @@ jobs:
           ccache --zero-stats
         shell: bash
 
-      - name: Export CUDA state as a variable for adding to cache key
-        run: |
-          build_type_cuda_state=nocuda
-          if [[ "${{ inputs.container-suffix }}" == "-cuda" ]]; then
-            build_type_cuda_state=cuda
-          fi
-          echo "BUILD_TYPE_CUDA_STATE=$build_type_cuda_state" >> "${GITHUB_ENV}"
-          echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
-        shell: bash
-
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
@@ -136,8 +129,7 @@ jobs:
         run: du -sh ${CCACHE_DIR} && ccache -s
         shell: bash
 
-      # Only keep save the -cuda version because cuda packages covers non-cuda packages too
-      - name: Push the ccache cache (if inputs.container-suffix == '-cuda' AND inputs.push-ccache)
+      - name: Push the ccache cache
         if: ${{ inputs.push-ccache }}
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/build-and-test-reusable.yaml
     with:
       runner: "['self-hosted', 'Linux', 'X64']"
-      container: ghcr.io/autowarefoundation/autoware:universe-devel
+      container: ghcr.io/autowarefoundation/autoware:core-devel-humble
       concurrency-group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: false
       pull-ccache: true

--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -24,7 +24,7 @@ jobs:
       - require-label
     uses: ./.github/workflows/build-and-test-differential.yaml
     with:
-      container: ghcr.io/autowarefoundation/autoware:core-devel
+      container: ghcr.io/autowarefoundation/autoware:core-devel-humble
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
@@ -35,5 +35,5 @@ jobs:
       - build-and-test-differential
     uses: ./.github/workflows/clang-tidy-differential.yaml
     with:
-      container: ghcr.io/autowarefoundation/autoware:core-devel
+      container: ghcr.io/autowarefoundation/autoware:core-devel-humble
       run-condition: true


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#6852
- Point [build-and-test.yaml](https://github.com/autowarefoundation/autoware_rviz_plugins/blob/584fd1be2b68c44a3c1f5da2d6e37663e0eab9ac/.github/workflows/build-and-test.yaml), [build-and-test-daily.yaml](https://github.com/autowarefoundation/autoware_rviz_plugins/blob/584fd1be2b68c44a3c1f5da2d6e37663e0eab9ac/.github/workflows/build-and-test-daily.yaml), [build-test-tidy-pr.yaml](https://github.com/autowarefoundation/autoware_rviz_plugins/blob/584fd1be2b68c44a3c1f5da2d6e37663e0eab9ac/.github/workflows/build-test-tidy-pr.yaml), and the [build-and-test-reusable.yaml](https://github.com/autowarefoundation/autoware_rviz_plugins/blob/584fd1be2b68c44a3c1f5da2d6e37663e0eab9ac/.github/workflows/build-and-test-reusable.yaml) default at the `core-devel-humble` image published by the consolidated docker pipeline (autowarefoundation/autoware#7040), replacing the tag-less `core-devel` / `universe-devel` images.
- Drop the stringly-typed `container-suffix` input on both reusable workflows ([build-and-test-reusable](https://github.com/autowarefoundation/autoware_rviz_plugins/blob/584fd1be2b68c44a3c1f5da2d6e37663e0eab9ac/.github/workflows/build-and-test-reusable.yaml), [build-and-test-differential](https://github.com/autowarefoundation/autoware_rviz_plugins/blob/584fd1be2b68c44a3c1f5da2d6e37663e0eab9ac/.github/workflows/build-and-test-differential.yaml)). CUDA state is now derived once at workflow-env scope via `BUILD_TYPE_CUDA_STATE: ${{ contains(inputs.container, '-cuda') && 'cuda' || 'nocuda' }}`, removing two identical "Export CUDA state" shell steps.
- Pin `CCACHE_DIR=/root/.ccache` in the two workflows that dereference `${CCACHE_DIR}`. Without this, the image-baked `CCACHE_DIR=/home/aw/.ccache` was inherited and diverged from the hard-coded `/root/.ccache` path used by `actions/cache`.
- Add `.github/actions/tune-dds-network` composite action and apply it in both build/test jobs (container now uses `--cap-add=NET_ADMIN`). GitHub Actions overrides the image entrypoint with `tail -f /dev/null`, so the entrypoint's loopback multicast + DDS tweaks never run. The composite enables multicast on `lo` and relaxes the CycloneDDS receive buffer minimum as a bridge until `docker/files/cyclonedds.xml` ships `min="default"` upstream.

## Why

The bake-based pipeline in autowarefoundation/autoware#7040 stops publishing the old tag-less `core-devel` / `universe-devel` images and replaces them with `<group>-<distro>` variants, one image per (group, rosdistro) pair. Without this change, CI here will 404 on image pull once that PR merges. The follow-ups (CUDA derivation, `CCACHE_DIR` pinning, DDS tune composite) clean up fragile couplings exposed by the image switchover itself and mirror the pattern from autowarefoundation/autoware_universe#12494.

---

- Depends on autowarefoundation/autoware#7040 for image availability.

## Test plan

- [x] [`build-and-test-daily`](https://github.com/autowarefoundation/autoware_rviz_plugins/actions/runs/24695034921) passes when dispatched manually via `workflow_dispatch`.
- [x] `build-test-tidy-pr` (both `build-and-test-differential` and `clang-tidy-differential` jobs) passes on this PR once the `run:build-and-test-differential` label is applied.
- [ ] `build-and-test` passes on the first push to `main` after merge.
