### PR TITLE
feat(perception): show bbox footprint

### DIFF
--- a/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -519,6 +519,9 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
     if (fill_type == ObjectFillType::Skeleton) {
       marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
       calc_bounding_box_line_list(shape_msg, marker_ptr->points);
+      if (!shape_msg.footprint.points.empty()) {
+        calc_polygon_line_list(shape_msg, marker_ptr->points);
+      }
     } else if (fill_type == ObjectFillType::Fill) {
       marker_ptr->type = visualization_msgs::msg::Marker::CUBE;
       marker_ptr->scale = shape_msg.dimensions;
@@ -564,6 +567,9 @@ visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
   if (shape_msg.type == Shape::BOUNDING_BOX) {
     marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
     calc_2d_bounding_box_bottom_line_list(shape_msg, marker_ptr->points);
+    if (!shape_msg.footprint.points.empty()) {
+      calc_2d_polygon_bottom_line_list(shape_msg, marker_ptr->points);
+    }
     if (is_orientation_available) {
       calc_2d_bounding_box_bottom_direction_line_list(shape_msg, marker_ptr->points);
     } else {


### PR DESCRIPTION
## Description

When `autoware_perception_msgs/Shape` carries `type == BOUNDING_BOX` with a non-empty `footprint` polygon (i.e., a bbox+polygon dual-shape), the footprint was silently ignored in RViz. This PR renders both the bounding box and the footprint polygon simultaneously.

**Changes:**
- `get_shape_marker_ptr` (3D skeleton mode): after drawing the bbox line list, additionally calls `calc_polygon_line_list` when `shape.footprint.points` is non-empty.
- `get_2d_shape_marker_ptr` (2D mode): after drawing the 2D bbox bottom line list, additionally calls `calc_2d_polygon_bottom_line_list` when `shape.footprint.points` is non-empty.

Both changes are guarded by `!shape_msg.footprint.points.empty()`, so existing pure-bbox objects (empty footprint) are unaffected.

## Related links

Feature PR https://github.com/autowarefoundation/autoware_universe/pull/12728 is necessary to see the updated objects messages.

## How was this PR tested?

<img width="1574" height="749" alt="Screenshot from 2026-06-09 20-40-28" src="https://github.com/user-attachments/assets/e7370cbe-ac9f-4e5e-9210-a2ebfbba44bd" />



Verified with tracked objects whose `Shape` carries both `BOUNDING_BOX` dimensions and a non-empty `footprint` polygon. Confirmed in RViz that:
- pure bounding-box objects (no footprint) render identically to before
- dual-shape objects display the bbox outline and the footprint polygon overlaid

## Notes for reviewers

This is the visualization complement to the bbox+polygon dual-shape tracker design: trackers store the physical footprint in `shape.footprint` while keeping `shape.type == BOUNDING_BOX` for kinematic purposes. This PR makes that dual-shape visible in RViz without changing any downstream message type or interface.

## Interface changes

None.

## Effects on system behavior

BOUNDING_BOX objects with a non-empty `footprint` polygon now render both the bbox wireframe and the footprint polygon in RViz (Skeleton and 2D modes). Objects without a footprint are unaffected.