### PR TITLE
ci: update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/bump-new-version.yaml
+++ b/.github/workflows/bump-new-version.yaml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   update-versions:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cancel-previous-workflows:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/clang-tidy-pr-comments-manually.yaml
+++ b/.github/workflows/clang-tidy-pr-comments-manually.yaml
@@ -12,7 +12,7 @@ on:
         required: true
 jobs:
   clang-tidy-pr-comments-manually:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/clang-tidy-pr-comments.yaml
+++ b/.github/workflows/clang-tidy-pr-comments.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   clang-tidy-pr-comments:
     if: ${{ github.event.workflow_run.event == 'pull_request' && contains(fromJson('["success", "failure"]'), github.event.workflow_run.conclusion) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/comment-on-pr.yaml
+++ b/.github/workflows/comment-on-pr.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/delete-closed-pr-docs.yaml
+++ b/.github/workflows/delete-closed-pr-docs.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   delete-closed-pr-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -31,7 +31,7 @@ jobs:
   deploy-docs:
     needs: prevent-no-label-execution
     if: ${{ needs.prevent-no-label-execution.outputs.run == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   github-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set tag name
         id: set-tag-name

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -18,7 +18,7 @@ jobs:
   pre-commit-autoupdate:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/release-new-version-when-merged.yaml
+++ b/.github/workflows/release-new-version-when-merged.yaml
@@ -12,7 +12,7 @@ jobs:
         join(github.event.pull_request.labels.*.name, ','),
         'release:bump-version'
       )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/spell-check-daily.yaml
+++ b/.github/workflows/spell-check-daily.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   spell-check-daily:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -18,7 +18,7 @@ jobs:
   sync-files:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -18,7 +18,7 @@ jobs:
   update-codeowners-from-packages:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Summary
- Update GitHub Actions `runs-on` runners from `ubuntu-22.04` to `ubuntu-24.04`
- `ubuntu-22.04-m` and other variant runners (e.g. `ubuntu-22.04-arm`) are unchanged

## Test plan
- [ ] Verify CI workflows pass on ubuntu-24.04 runners